### PR TITLE
move object types widget and adapt to volto-resize-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "md5": "^2.3.0"
   },
+  "dependencies": {
+    "@eeacms/volto-resize-helper": "1.3.1"
+  },
   "scripts": {
     "release": "release-it",
     "release-major-beta": "release-it major --preRelease=beta",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "md5": "^2.3.0"
   },
   "dependencies": {
-    "@eeacms/volto-resize-helper": "1.3.1"
+    "@eeacms/volto-resize-helper": "*"
   },
   "scripts": {
     "release": "release-it",

--- a/src/Widget/ObjectTypesWidget.jsx
+++ b/src/Widget/ObjectTypesWidget.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { Menu, Tab } from 'semantic-ui-react';
+import { ObjectWidget } from '@plone/volto/components';
+import { connect } from 'react-redux';
+
+const getDeviceConfig = (width) => {
+  // semantic ui breakpoints
+  if (width < 320) {
+    return 'mobile';
+  } else if (width >= 320 && width < 768) {
+    return 'tablet';
+  } else if (width >= 768 && width < 992) {
+    return 'computer';
+  } else if (width >= 992 && width < 1280) {
+    return 'large';
+  } else if (width >= 1280) {
+    return 'widescreen';
+  }
+};
+
+export const ObjectTypesWidget = (props) => {
+  const {
+    schemas,
+    value = {},
+    onChange,
+    errors = {},
+    id,
+    block,
+    screen,
+  } = props;
+  const objectId = id;
+
+  const defaultActiveTab = 0;
+
+  const [activeTab, setActiveTab] = React.useState(
+    defaultActiveTab > -1 ? defaultActiveTab : 0,
+  );
+
+  const device = screen?.page?.width
+    ? getDeviceConfig(screen?.page?.width)
+    : '';
+
+  const createTab = ({ schema, id, icon }, index) => {
+    return {
+      menuItem: () => (
+        <Menu.Item
+          onClick={() => setActiveTab(index)}
+          active={activeTab === index}
+          key={id}
+        >
+          <p style={{ fontSize: '14px', fontWeight: 'bold' }}>{schema.title}</p>
+        </Menu.Item>
+      ),
+      render: () => {
+        return (
+          <Tab.Pane style={{ padding: '0' }}>
+            <ObjectWidget
+              schema={schema}
+              id={id}
+              block={block}
+              errors={errors}
+              value={value[id] || {}}
+              onChange={(schemaId, v) => {
+                onChange(objectId, { ...value, [schemaId]: v });
+              }}
+            />
+          </Tab.Pane>
+        );
+      },
+    };
+  };
+
+  return (
+    <Tab
+      menu={{
+        vertical:
+          device === 'computer' || device === 'tablet' || device === 'mobile'
+            ? false
+            : true,
+        tabular: true,
+      }}
+      panes={schemas.map(createTab)}
+      activeIndex={activeTab}
+      grid={{ paneWidth: 9, tabWidth: 3 }}
+    />
+  );
+};
+
+export default connect(
+  (state, props) => ({
+    screen: state?.screen,
+  }),
+  {},
+)(ObjectTypesWidget);

--- a/src/Widget/index.js
+++ b/src/Widget/index.js
@@ -3,3 +3,4 @@ export ObjectListWidget from './ObjectListWidget';
 export ObjectListInlineWidget from './ObjectListInlineWidget';
 export ObjectByTypeWidget from './ObjectByTypeWidget';
 export MappingWidget from './MappingWidget';
+export ObjectTypesWidget from './ObjectTypesWidget';

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import {
   ObjectListInlineWidget,
   ObjectByTypeWidget,
   MappingWidget,
+  ObjectTypesWidget,
 } from './Widget';
 
 export {
@@ -11,6 +12,7 @@ export {
   ObjectListInlineWidget,
   ObjectByTypeWidget,
   MappingWidget,
+  ObjectTypesWidget,
 } from './Widget';
 
 export installDemo from './demo';
@@ -22,6 +24,7 @@ const applyConfig = (config) => {
     config.widgets.widget.object_by_type = ObjectByTypeWidget;
     config.widgets.widget.option_mapping = MappingWidget;
     config.widgets.widget.attachedimage = AttachedImageWidget;
+    config.widgets.widget.object_types_widget = ObjectTypesWidget;
   }
 
   return config;


### PR DESCRIPTION
ObjectTypesWidget. A widget initially designed for volto-eea-map moved here to solve some dependency issue when used by other addons (eg. volto-tableau )