### PR TITLE
allow attachedImageWidget to use also object browser values for backw…

### DIFF
--- a/src/Widget/AttachedImageWidget.jsx
+++ b/src/Widget/AttachedImageWidget.jsx
@@ -34,6 +34,13 @@ const messages = defineMessages({
   },
 });
 
+const formatURL = (url) => {
+  if (url === undefined) return '';
+  if (typeof url === 'string') return url;
+  if (Array.isArray(url)) return formatURL(url?.[0]);
+  if (typeof url === 'object') return formatURL(url?.['@id']);
+};
+
 export class AttachedImageWidget extends Component {
   /**
    * Property types.
@@ -210,11 +217,11 @@ export class AttachedImageWidget extends Component {
           <div className="preview">
             <img
               src={
-                isInternalURL(this.props.value)
+                isInternalURL(formatURL(this.props.value))
                   ? `${flattenToAppURL(
-                      this.props.value,
+                      formatURL(this.props.value),
                     )}/@@images/image/preview`
-                  : this.props.value
+                  : formatURL(this.props.value)
               }
               alt="Preview"
             />


### PR DESCRIPTION
This is useful when you decide for example to use attachedimage widget instead of an object_browser widget on an existing site.